### PR TITLE
Kara definitions

### DIFF
--- a/ScoringDefinitions.md
+++ b/ScoringDefinitions.md
@@ -8,7 +8,7 @@
 
 **Definition:** The **Ordering Score** is calculated as the Sugeno Integral, which is based on the concepts of "fuzzy measures" and "fuzzy integral", as described in Fuzzy Set Theory. The Ordering Score is based on three scoring factors: **Confidence Score**; **Clinical Evidence Score**; and **Novelty Score**. The fuzzy integral is used to aggregate those factors. The Ordering Score or Sugeno considers the aggregated importance of combinations of the scoring factors, where higher values are treated with greater importance than lower values, and it intuits that factors with low scores are not as relevant or important to the aggregation than factors with high scores.
 
-*Special Note:* The ordering score is being used by the UI, which displays a variation of this score that is scaled 0 to 5.
+*Special Note: The ordering score is being used by the UI, which displays a variation of this score that is scaled 0 to 5.*
 
 ### Confidence Score
 
@@ -44,7 +44,7 @@
 
 **Synonyms:** Approval Status
 
-**Defintion:** **FDA Approval Status** is provided for predicted drug treatments and refers to the clinical research phases required for US FDA approval of a new pharmaceutical or a new indication for an existing pharmaceutical. This FDA Approval Status is specific to the disease that is part of the result. For the Novelty Score, FDA approval Status is treated as a binary value of 0 (FDA Approval for Marketing / FDA Clinical Research Phase 4) or 1 (FDA Clinical Research Phase 1, 2, or 3). Note that the source from which the FDA Approval Status is derived is ChEMBL (https://www.ebi.ac.uk/chembl/), which does not distinguish between FDA Approval for Marketing and FDA Clinical Research Phase 4. If a predicted drug treatment is a chemical entity that is not in clinical trials, then FDA approval status is treated as null and does not factor into the Novelty Score.
+**Defintion:** **FDA Approval Status** is provided for predicted drug treatments and refers to the clinical research phases required for US FDA approval of a new pharmaceutical or a new indication for an existing pharmaceutical. _This FDA Approval Status is specific to the disease that is part of the result._ For the Novelty Score, FDA approval Status is treated as a binary value of 0 (FDA Approval for Marketing / FDA Clinical Research Phase 4) or 1 (FDA Clinical Research Phase 1, 2, or 3). Note that the source from which the FDA Approval Status is derived is ChEMBL (https://www.ebi.ac.uk/chembl/), which does not distinguish between FDA Approval for Marketing and FDA Clinical Research Phase 4. If a predicted drug treatment is a chemical entity that is not in clinical trials, then FDA approval status is treated as null and does not factor into the Novelty Score.
 
 ![O O-graphic](https://github.com/NCATSTranslator/Ordering-Organizing/assets/26254388/34fd08ca-d9c9-45bf-8757-1045a3557555)
 


### PR DESCRIPTION
@NCATSTranslator/ordering-organizing :

This PR creates a markdown file with updated O&O scoring definitions and a high-level graphic relating the various scores and contributing factors. Please vote with a +1 to approve the definitions or otherwise comment.

Please note that the requested vote on scoring definitions is for external-facing (UI) purposes only. For internal purposes (CI deployment), two Ordering Scores will be defined per Link Brokers as follows and used for evaluation purposes only:

1. Ordering Score with Novelty (suggested abbreviation: "Ordering-N"): Confidence + Clinical + Novelty
2. Ordering Score Without Novelty (suggested abbreviation: "Ordering-NoN"): Confidence + Clinical

Please also note that the voting period will remain open until **EOD Tuesday, December 12**.

Thanks!
